### PR TITLE
Fix `async-node example`

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -34,6 +34,7 @@ To run this example:
 
 ```
 git clone git@github.com:zeit/async-throttle
+cd async-throttle
 npm install
-async-node example.js
+npm run example
 ```

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "index.js"
   ],
   "scripts": {
-    "test": "ava"
+    "test": "ava",
+    "example": "async-node example"
   },
   "description": "Throttle asynchronous Promise-based tasks",
   "devDependencies": {


### PR DESCRIPTION
The command `$ async-node example.js` does not work unless the client has `async-to-gen` installed globally on npm.

Adding this script to the `package.json` allows the client to run the script, which will use the locally installed version of `async-to-gen`.

Updates README.md steps.