### PR TITLE
Migrate linting tool to XO

### DIFF
--- a/example.js
+++ b/example.js
@@ -1,16 +1,16 @@
 const fetch = require('node-fetch')
-const createThrottle = require('./')
 const cheerio = require('cheerio').load
+const createThrottle = require('./')
 
 // code
 const throttle = createThrottle(2)
 const urls = ['https://zeit.co', 'https://google.com', 'https://bing.com', 'https://test.com', 'http://cnn.com', 'https://woot.com']
-Promise.all(urls.map((url) => throttle(async () => {
+Promise.all(urls.map(url => throttle(async () => {
   console.log('Processing', url)
   const res = await fetch(url)
   const data = await res.text()
   const $ = cheerio(data)
   return $('title').text()
 })))
-.then((titles) => console.log('Titles:', titles))
-.catch((err) => console.error(err.stack))
+.then(titles => console.log('Titles:', titles))
+.catch(err => console.error(err.stack))

--- a/index.js
+++ b/index.js
@@ -1,41 +1,44 @@
-"use strict"
+'use strict'
 
-module.exports = function createThrottle (max) {
+module.exports = function (max) {
   if (typeof max !== 'number') {
     throw new TypeError('`createThrottle` expects a valid Number')
   }
 
   let cur = 0
   const queue = []
-  return function throttled (fn) {
-    return new Promise(function (resolve, reject) {
-
+  return function (fn) {
+    return new Promise((resolve, reject) => {
       function handleFn() {
         cur++
         fn()
-          .then(function (val) {
+          .then(val => {
             resolve(val)
             cur--
-            if (queue.length) queue.shift()()
+            if (queue.length > 0) {
+              queue.shift()()
+            }
           })
-          .catch(function (err) {
+          .catch(err => {
             reject(err)
             cur--
-            if (queue.length) queue.shift()()
+            if (queue.length > 0) {
+              queue.shift()()
+            }
           })
       }
 
       if (cur < max) {
         handleFn()
+      } else if (cur < max) {
+        // avoid a race condition where the
+        // concurrency went down prior to this
+        // promise being executed in a microtask
+        handleFn()
       } else {
-        if (cur < max) {
-          // avoid a race condition where the
-          // concurrency went down prior to this
-          // promise being executed in a microtask
+        queue.push(() => {
           handleFn()
-        } else {
-          queue.push(() => { handleFn() })
-        }
+        })
       }
     })
   }

--- a/package.json
+++ b/package.json
@@ -7,30 +7,28 @@
     "index.js"
   ],
   "scripts": {
-    "test": "ava",
+    "test": "xo && ava",
     "example": "async-node example"
   },
   "description": "Throttle asynchronous Promise-based tasks",
   "devDependencies": {
-    "ava": "0.16.0",
     "async-to-gen": "1.1.3",
+    "ava": "0.16.0",
     "babel-eslint": "7.0.0",
     "cheerio": "0.22.0",
-    "eslint": "3.6.1",
-    "eslint-config-standard": "6.2.0",
-    "eslint-plugin-promise": "2.0.1",
-    "eslint-plugin-standard": "2.0.1",
     "node-fetch": "1.6.3",
-    "then-sleep": "1.0.1"
-  },
-  "eslintConfig": {
-    "extends": "standard",
-    "parser": "babel-eslint"
+    "then-sleep": "1.0.1",
+    "xo": "^0.17.0"
   },
   "ava": {
     "files": [
       "test.js"
     ],
     "require": "async-to-gen/register"
+  },
+  "xo": {
+    "esnext": true,
+    "space": true,
+    "semicolon": false
   }
 }

--- a/test.js
+++ b/test.js
@@ -1,8 +1,8 @@
 const test = require('ava')
-const createThrottle = require('./')
 const sleep = require('then-sleep')
+const createThrottle = require('./')
 
-test('test concurrency of 1', async (t) => {
+test('test concurrency of 1', async t => {
   const throttle = createThrottle(1)
   const pending = []
 
@@ -11,17 +11,19 @@ test('test concurrency of 1', async (t) => {
 
   // measure total executions
   let total = 0
-  let expected = 10
+  const expected = 10
+
+  const fn = async () => {
+    cur++
+    t.is(cur, 1)
+    await sleep(100)
+    cur--
+    t.is(cur, 0)
+    total++
+  }
 
   for (let a = 0; a < expected; a++) {
-    pending.push(throttle(async () => {
-      cur++
-      t.is(cur, 1)
-      await sleep(100)
-      cur--
-      t.is(cur, 0)
-      total++
-    }))
+    pending.push(throttle(fn))
   }
 
   // wait on all tasks
@@ -31,7 +33,7 @@ test('test concurrency of 1', async (t) => {
   t.is(total, expected)
 })
 
-test('test concurrency of 2', async (t) => {
+test('test concurrency of 2', async t => {
   const throttle = createThrottle(2)
   const pending = []
 
@@ -40,21 +42,27 @@ test('test concurrency of 2', async (t) => {
 
   // measure total executions
   let total = 0
-  let expected = 10
+  const expected = 10
   let wasTwo = false
   let wasZero = false
 
+  const fn = async () => {
+    cur++
+    t.true(cur <= 2)
+    if (cur === 2) {
+      wasTwo = true
+    }
+    await sleep(100)
+    cur--
+    t.true(cur <= 2)
+    if (cur === 0) {
+      wasZero = true
+    }
+    total++
+  }
+
   for (let a = 0; a < expected; a++) {
-    pending.push(throttle(async () => {
-      cur++
-      t.true(cur <= 2)
-      if (cur === 2) wasTwo = true
-      await sleep(100)
-      cur--
-      t.true(cur <= 2)
-      if (cur === 0) wasZero = true
-      total++
-    }))
+    pending.push(throttle(fn))
   }
 
   // wait on all tasks
@@ -66,7 +74,7 @@ test('test concurrency of 2', async (t) => {
   t.true(wasTwo)
 })
 
-test('error', (t) => {
+test('error', t => {
   try {
     createThrottle(null)
   } catch (err) {
@@ -74,7 +82,7 @@ test('error', (t) => {
   }
 })
 
-test('return values', async (t) => {
+test('return values', async t => {
   const throttle = createThrottle(1)
   const val = await throttle(async () => {
     await sleep(100)
@@ -83,11 +91,11 @@ test('return values', async (t) => {
   t.is(val, 'haha')
 })
 
-test('errors should not interrupt the queue', async (t) => {
+test('errors should not interrupt the queue', async t => {
   const throttle = createThrottle(1)
   const p1 = throttle(async () => {
     await sleep(100)
-    throw Error('haha')
+    throw new Error('haha')
   })
   const p2 = throttle(async () => {
     await sleep(100)
@@ -95,10 +103,10 @@ test('errors should not interrupt the queue', async (t) => {
   })
 
   // make sure it threw
-  await new Promise((resolve) => {
-    p1.catch((err) => {
+  await new Promise(resolve => {
+    p1.catch(err => {
       t.true(err instanceof Error)
-      p2.then((data) => {
+      p2.then(data => {
         t.is(data, 'woot')
         resolve()
       })


### PR DESCRIPTION
This migrates the linting tool from standard to XO to have a consistent linter and style accross the Zeit projects, as request by @leo.