### PR TITLE
BREAKING: Return a throttled function

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,13 +18,13 @@ but it processes a maximum of **two at a time**.
 ```js
 // deps
 const fetch = require('node-fetch')
-const createThrottle = require('async-throttle')
 const cheerio = require('cheerio').load
+const createThrottle = require('async-throttle')
 
 // code
 const throttle = createThrottle(2)
 const urls = ['https://zeit.co', 'https://google.com', /* … */]
-Promise.all(urls.map((url) => throttle(async () => {
+Promise.all(urls.map(throttle(async url => {
   console.log('Processing', url)
   const res = await fetch(url)
   const data = await res.text()
@@ -40,5 +40,5 @@ To run this example:
 git clone git@github.com:zeit/async-throttle
 cd async-throttle
 npm install
-npm run example
+node example
 ```

--- a/example.js
+++ b/example.js
@@ -5,12 +5,15 @@ const createThrottle = require('./')
 // code
 const throttle = createThrottle(2)
 const urls = ['https://zeit.co', 'https://google.com', 'https://bing.com', 'https://test.com', 'http://cnn.com', 'https://woot.com']
-Promise.all(urls.map(url => throttle(async () => {
+
+const getTitle = async url => {
   console.log('Processing', url)
   const res = await fetch(url)
   const data = await res.text()
   const $ = cheerio(data)
   return $('title').text()
-})))
-.then(titles => console.log('Titles:', titles))
-.catch(err => console.error(err.stack))
+}
+
+Promise.all(urls.map(throttle(getTitle)))
+  .then(titles => console.log('Titles:', titles))
+  .catch(err => console.error(err.stack))

--- a/index.js
+++ b/index.js
@@ -8,35 +8,40 @@ function createThrottle(max) {
   let cur = 0
   const queue = []
   function throttle(fn) {
-    return new Promise((resolve, reject) => {
-      function handleFn() {
-        if (cur < max) {
-          throttle.current = ++cur
-          fn()
-            .then(val => {
-              resolve(val)
-              throttle.current = --cur
-              if (queue.length > 0) {
-                queue.shift()()
-              }
-            })
-            .catch(err => {
-              reject(err)
-              throttle.current = --cur
-              if (queue.length > 0) {
-                queue.shift()()
-              }
-            })
-        } else {
-          queue.push(handleFn)
+    function throttled() {
+      const self = this
+      const args = arguments
+      return new Promise((resolve, reject) => {
+        function handleFn() {
+          if (cur < max) {
+            throttle.current = ++cur
+            Promise.resolve(fn.apply(self, args))
+              .then(val => {
+                resolve(val)
+                throttle.current = --cur
+                if (queue.length > 0) {
+                  queue.shift()()
+                }
+              })
+              .catch(err => {
+                reject(err)
+                throttle.current = --cur
+                if (queue.length > 0) {
+                  queue.shift()()
+                }
+              })
+          } else {
+            queue.push(handleFn)
+          }
         }
-      }
 
-      handleFn()
-    })
+        handleFn()
+      })
+    }
+    return throttled
   }
 
-  // keep copies of the "state" for retrospection
+  // keep copies of the "state" for introspection
   throttle.current = cur
   throttle.queue = queue
 

--- a/package.json
+++ b/package.json
@@ -7,14 +7,11 @@
     "index.js"
   ],
   "scripts": {
-    "test": "xo && ava",
-    "example": "async-node example"
+    "test": "xo && ava"
   },
   "description": "Throttle asynchronous Promise-based tasks",
   "devDependencies": {
-    "async-to-gen": "1.1.3",
     "ava": "0.16.0",
-    "babel-eslint": "7.0.0",
     "cheerio": "0.22.0",
     "node-fetch": "1.6.3",
     "then-sleep": "1.0.1",
@@ -23,8 +20,7 @@
   "ava": {
     "files": [
       "test.js"
-    ],
-    "require": "async-to-gen/register"
+    ]
   },
   "xo": {
     "esnext": true,


### PR DESCRIPTION
This is a pretty heavy refactor that makes `async-throttle`
have the pretty API I've always dreamed that it should.

Previously you'd use throttle with `.map()` like so:

```js
Promise.all(urls.map((url) => throttle(async () => {
  // ...
})))
```

There's an anonymous function that is given the map argument, which
returns a call to `throttle()` which basically needs another anonymous
function to be passed to it in order to get the map() argument via
closure. Pretty nasty!

Now we can do this:

```js
const throttled = throttle(async url => {
  // ...
})
Promise.all(urls.map(throttled))
```

The `throttled` function is cached and the syntax is a lot cleaner.

The arguments passed when .map() is invoked get properly passed
to the throttled function, as well as the `this` context if that is set.

Tests updated and a few new cases added for the new behavior.